### PR TITLE
Allow capitalized tags

### DIFF
--- a/lib/live_view_native/tag_engine.ex
+++ b/lib/live_view_native/tag_engine.ex
@@ -4,8 +4,13 @@ defmodule LiveViewNative.TagEngine do
   def classify_type(":inner_block"), do: {:error, "the slot name :inner_block is reserved"}
   def classify_type(":" <> name), do: {:slot, String.to_atom(name)}
 
-  def classify_type(<<first, _::binary>> = name) when first in ?A..?Z,
-    do: {:remote_component, String.to_atom(name)}
+  def classify_type(<<first, _::binary>> = name) when first in ?A..?Z do
+    if String.contains?(name, ".") do
+      {:remote_component, String.to_atom(name)}
+    else
+      {:tag, name}
+    end
+  end
 
   def classify_type("." <> name),
     do: {:local_component, String.to_atom(name)}

--- a/test/live_view_native/tag_engine_test.exs
+++ b/test/live_view_native/tag_engine_test.exs
@@ -23,6 +23,10 @@ defmodule LiveViewNative.TagEngineTest do
     test "it returns all other tagas as they are" do
       assert TagEngine.classify_type("test") == {:tag, "test"}
     end
+
+    test "it returns a tag when name is a capitalized string without a dot" do
+      assert TagEngine.classify_type("Foo") == {:tag, "Foo"}
+    end
   end
 
   describe "void?/1" do


### PR DESCRIPTION
This allows capitalized names to be treated as tags and not remote components.

Remote components are identified as having a `.` in their name:
```heex
<Remote.component>...</Remote.component>
```

Capitalized tags have no `.` in their name:
```heex
<CapitalizedTag>...</CapitalizedTag>
```