### PR TITLE
Add support for inline templates

### DIFF
--- a/lib/live_view_native/extensions.ex
+++ b/lib/live_view_native/extensions.ex
@@ -25,9 +25,15 @@ defmodule LiveViewNative.Extensions do
             template_directory: Path.dirname(__ENV__.file),
             template_extension: platform_context.template_extension || ".#{platform_id}.heex"
         end
+
+        use LiveViewNative.Extensions.Modifiers,
+          custom_modifiers: platform_context.custom_modifiers || [],
+          platform_modifiers: platform_context.platform_modifiers || [],
+          platform_module: platform_module
       end
 
       use LiveViewNative.Extensions.Render
+      use LiveViewNative.Extensions.InlineRender
     end
   end
 end

--- a/lib/live_view_native/extensions/inline_render.ex
+++ b/lib/live_view_native/extensions/inline_render.ex
@@ -1,6 +1,31 @@
 defmodule LiveViewNative.Extensions.InlineRender do
   @moduledoc """
+  LiveView Native extension that enables inline-rendering of templates for LiveView
+  Native platforms within a LiveView or Live Component. Using this macro causes
+  a module to inherit a `Z/2` sigil that can be used to render templates inline
+  by suffixing it with the platform's `platform_id`:
 
+  ```elixir
+  defmodule ScratchboardWeb.SigilTestLive do
+    use Phoenix.LiveView
+    use LiveViewNative.LiveView
+
+    @impl true
+    def render(%{platform_id: :ios} = assigns) do
+      ~Z\"\"\"
+      <Text modifiers={@native |> foreground_style(primary: {:color, :mint})}>
+        Hello from iOS!
+      </Text>
+      \"\"\"ios
+    end
+
+    def render(assigns) do
+      ~H\"\"\"
+      <div>Hello from the web!</div>
+      \"\"\"
+    end
+  end
+  ```
   """
   defmacro __using__(_opts \\ []) do
     quote bind_quoted: [] do

--- a/lib/live_view_native/extensions/inline_render.ex
+++ b/lib/live_view_native/extensions/inline_render.ex
@@ -6,12 +6,12 @@ defmodule LiveViewNative.Extensions.InlineRender do
   by suffixing it with the platform's `platform_id`:
 
   ```elixir
-  defmodule ScratchboardWeb.SigilTestLive do
+  defmodule MyAppWeb.HelloLive do
     use Phoenix.LiveView
     use LiveViewNative.LiveView
 
     @impl true
-    def render(%{platform_id: :ios} = assigns) do
+    def render(%{platform_id: :swiftui} = assigns) do
       ~Z\"\"\"
       <Text modifiers={@native |> foreground_style(primary: {:color, :mint})}>
         Hello from iOS!

--- a/lib/live_view_native/extensions/inline_render.ex
+++ b/lib/live_view_native/extensions/inline_render.ex
@@ -1,0 +1,33 @@
+defmodule LiveViewNative.Extensions.InlineRender do
+  @moduledoc """
+
+  """
+  defmacro __using__(_opts \\ []) do
+    quote bind_quoted: [] do
+      require EEx
+
+      defmacro sigil_Z({:<<>>, meta, [expr]}, modifiers) do
+        unless Macro.Env.has_var?(__CALLER__, {:assigns, nil}) do
+          raise "~Z requires a variable named \"assigns\" to exist and be set to a map"
+        end
+
+        with %{} = platforms <- LiveViewNative.platforms(),
+             %LiveViewNativePlatform.Context{} = context <- Map.get(platforms, "#{modifiers}"),
+             platform_module <- Module.concat(__ENV__.module, context.template_namespace)
+        do
+          options = [
+            engine: Phoenix.LiveView.TagEngine,
+            file: __CALLER__.file,
+            line: __CALLER__.line + 1,
+            caller: __CALLER__,
+            indentation: meta[:indentation] || 0,
+            source: expr,
+            tag_handler: LiveViewNative.TagEngine
+          ]
+
+          EEx.compile_string(expr, options)
+        end
+      end
+    end
+  end
+end

--- a/lib/live_view_native/extensions/modifiers.ex
+++ b/lib/live_view_native/extensions/modifiers.ex
@@ -39,7 +39,9 @@ defmodule LiveViewNative.Extensions.Modifiers do
         end
       else
         for {modifier_key, modifier_module} <- all_modifiers do
-          defdelegate unquote(:"#{modifier_key}")(ctx, params), to: platform_module
+          def unquote(:"#{modifier_key}")(ctx, params) do
+            apply(unquote(platform_module), unquote(:"#{modifier_key}"), [ctx, params])
+          end
         end
       end
     end

--- a/lib/live_view_native/live_session.ex
+++ b/lib/live_view_native/live_session.ex
@@ -9,13 +9,22 @@ defmodule LiveViewNative.LiveSession do
     with %{"_platform" => platform_id} <- get_connect_params(socket),
          platforms <- LiveViewNative.platforms(),
          %LiveViewNativePlatform.Context{} = platform_context <- Map.get(platforms, platform_id) do
-      {:cont, assign(socket, :native, platform_context)}
+      socket =
+        socket
+        |> assign(:native, platform_context)
+        |> assign(:platform_id, platform_context.platform_id)
+
+      {:cont, socket}
     else
       _result ->
         platform_config = %LiveViewNative.Platforms.Web{}
         platform_context = LiveViewNativePlatform.context(platform_config)
+        socket =
+          socket
+          |> assign(:native, platform_context)
+          |> assign(:platform_id, platform_context.platform_id)
 
-        {:cont, assign(socket, :native, platform_context)}
+        {:cont, socket}
     end
   end
 end

--- a/test/live_view_native/live_session_test.exs
+++ b/test/live_view_native/live_session_test.exs
@@ -7,7 +7,7 @@ defmodule LiveViewNative.LiveSessionTest do
   describe "on_mount/4" do
     test "assigns a @native assign with the correct platform configuration" do
       socket = %Socket{
-        private: %{connect_params: %{"_platform" => "_live_view_native_test_internal"}},
+        private: %{connect_params: %{"_platform" => "lvntest"}},
         transport_pid: self()
       }
 
@@ -16,7 +16,7 @@ defmodule LiveViewNative.LiveSessionTest do
       assert updated_socket.assigns
       assert updated_socket.assigns.native
       assert updated_socket.assigns.native.__struct__ == LiveViewNativePlatform.Context
-      assert updated_socket.assigns.native.platform_id == :_live_view_native_test_internal
+      assert updated_socket.assigns.native.platform_id == :lvntest
 
       assert updated_socket.assigns.native.platform_config == %LiveViewNative.TestPlatform{
                testing_notes: "everything is ok"

--- a/test/live_view_native/live_view_test.exs
+++ b/test/live_view_native/live_view_test.exs
@@ -2,6 +2,7 @@ defmodule LiveViewNative.LiveViewTest do
   use ExUnit.Case
 
   alias LiveViewNative.TestLiveView
+  alias LiveViewNative.TestLiveViewInline
 
   test "modules using LiveViewNative have a render_native/1 function" do
     Code.ensure_compiled(LiveViewNative.TestLiveView)
@@ -12,8 +13,8 @@ defmodule LiveViewNative.LiveViewTest do
   test "calling render_native/1 renders the correct platform for `assigns`" do
     web_context = LiveViewNativePlatform.context(%LiveViewNative.Platforms.Web{})
     test_context = LiveViewNativePlatform.context(%LiveViewNative.TestPlatform{})
-    web_result = TestLiveView.render(%{native: web_context})
-    test_result = TestLiveView.render(%{native: test_context})
+    web_result = TestLiveView.render(%{platform_id: :web, native: web_context})
+    test_result = TestLiveView.render(%{platform_id: :lvntest, native: test_context})
 
     assert web_result.static == [
              "<div>\n  <span>This is an HTML template</span>\n  <input>\n</div>"
@@ -22,5 +23,15 @@ defmodule LiveViewNative.LiveViewTest do
     assert test_result.static == [
              "<div>\n  <span>This is not an HTML template</span>\n  <input>\n    <faketag>(not actually HTML)</faketag>\n  </input>\n</div>"
            ]
+  end
+
+  test "calling render/1 renders platform-specific templates inline" do
+    web_context = LiveViewNativePlatform.context(%LiveViewNative.Platforms.Web{})
+    test_context = LiveViewNativePlatform.context(%LiveViewNative.TestPlatform{})
+    web_result = TestLiveViewInline.render(%{platform_id: :web, native: web_context})
+    test_result = TestLiveViewInline.render(%{platform_id: :lvntest, native: test_context})
+
+    assert web_result.static == ["<div>Hello from the web</div>"]
+    assert test_result.static == ["<Text>Hello from the test platform</Text>"]
   end
 end

--- a/test/live_view_native_test.exs
+++ b/test/live_view_native_test.exs
@@ -7,15 +7,15 @@ defmodule LiveViewNativeTest do
     assert platforms
     assert is_map(platforms)
     assert platforms["web"]
-    assert platforms["_live_view_native_test_internal"]
+    assert platforms["lvntest"]
   end
 
   describe "platform/1" do
     test "when platform_id is a non-nil atom" do
-      {:ok, platform_struct} = LiveViewNative.platform(:_live_view_native_test_internal)
+      {:ok, platform_struct} = LiveViewNative.platform(:lvntest)
 
       assert platform_struct
-      assert platform_struct.platform_id == :_live_view_native_test_internal
+      assert platform_struct.platform_id == :lvntest
 
       assert platform_struct.platform_config == %LiveViewNative.TestPlatform{
                testing_notes: "everything is ok"
@@ -50,7 +50,7 @@ defmodule LiveViewNativeTest do
   describe "start_simulator!/1" do
     test "it starts a simulator for the given platform" do
       web_result = LiveViewNative.start_simulator!(:web)
-      test_result = LiveViewNative.start_simulator!(:_live_view_native_test_internal)
+      test_result = LiveViewNative.start_simulator!(:lvntest)
 
       assert web_result == {:ok, :skipped}
       assert test_result == {:ok, "start_simulator/2 was called from LiveViewNative.TestPlatform"}

--- a/test/support/test_live_view_inline.ex
+++ b/test/support/test_live_view_inline.ex
@@ -1,0 +1,17 @@
+defmodule LiveViewNative.TestLiveViewInline do
+  use Phoenix.LiveView
+  use LiveViewNative.LiveView
+
+  @impl true
+  def render(%{platform_id: :lvntest} = assigns) do
+    ~Z"""
+    <Text>Hello from the test platform</Text>
+    """lvntest
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div>Hello from the web</div>
+    """
+  end
+end

--- a/test/support/test_platform.ex
+++ b/test/support/test_platform.ex
@@ -3,7 +3,7 @@ defmodule LiveViewNative.TestPlatform do
 
   defimpl LiveViewNativePlatform do
     def context(_struct) do
-      LiveViewNativePlatform.Context.define(:_live_view_native_test_internal,
+      LiveViewNativePlatform.Context.define(:lvntest,
         template_extension: ".test.heex",
         template_namespace: Test,
         otp_app: :live_view_native


### PR DESCRIPTION
This PR adds support for inline rendering of templates for non-web LiveView Native platforms:

```elixir
defmodule ScratchboardWeb.SigilTestLive do
  use Phoenix.LiveView
  use LiveViewNative.LiveView

  @impl true
  def render(%{platform_id: :swiftui} = assigns) do
    ~Z"""
    <Text modifiers={@native |> foreground_style(primary: {:color, :mint})}>
      Hello from iOS!
    </Text>
    """swiftui
  end

  def render(assigns) do
    ~H"""
    <div>Hello from the web!</div>
    """
  end
end
```

The `~Z` sigil is used as a placeholder until https://github.com/elixir-lang/elixir/pull/12448 is included in a release at which point we will switch to a multi-char sigil (probably `~LVN`).