### PR TITLE
Add default to modifier params

### DIFF
--- a/lib/live_view_native/extensions/modifiers.ex
+++ b/lib/live_view_native/extensions/modifiers.ex
@@ -39,7 +39,7 @@ defmodule LiveViewNative.Extensions.Modifiers do
         end
       else
         for {modifier_key, modifier_module} <- all_modifiers do
-          def unquote(:"#{modifier_key}")(ctx, params) do
+          def unquote(:"#{modifier_key}")(ctx, params \\ %{}) do
             apply(unquote(platform_module), unquote(:"#{modifier_key}"), [ctx, params])
           end
         end


### PR DESCRIPTION
This makes it possible to use modifier such as `bold(@native)` without needing to pass `bold(@native, %{})`.
Closes #18 