### PR TITLE
Add persistence events

### DIFF
--- a/lib/live_view_native/extensions.ex
+++ b/lib/live_view_native/extensions.ex
@@ -41,6 +41,7 @@ defmodule LiveViewNative.Extensions do
       use LiveViewNative.Extensions.Render
       use LiveViewNative.Extensions.InlineRender
       use LiveViewNative.Extensions.Bindings
+      use LiveViewNative.Extensions.Persistence
     end
   end
 end

--- a/lib/live_view_native/extensions/persistence.ex
+++ b/lib/live_view_native/extensions/persistence.ex
@@ -1,0 +1,26 @@
+defmodule LiveViewNative.Extensions.Persistence do
+  import Phoenix.Component
+  import Phoenix.LiveView
+
+  defmacro __using__(_opts \\ []) do
+    quote do
+      import unquote(__MODULE__)
+    end
+  end
+
+  def push_persistent_value(socket, key, value, opts \\ []) do
+    push_event(
+      socket,
+      "_native_persistence_store",
+      %{ value: value, key: key, options: Enum.into(opts, %{}) }
+    )
+  end
+
+  def load_persistent_value(socket, key, event, opts \\ []) do
+    push_event(
+      socket,
+      "_native_persistence_load",
+      %{ key: key, event: event, options: Enum.into(opts, %{}) }
+    )
+  end
+end


### PR DESCRIPTION
This is related to https://github.com/liveview-native/liveview-client-swiftui/pull/1065, and introduces an alternative to `native_binding` for simplified persistence.

Here's an example of a counter app that persists the count in UserDefaults.

```elixir
defmodule TestBedWeb.IndexLive do
  use TestBedWeb, :live_view
  use LiveViewNative.LiveView

  @impl true
  def mount(_params, _session, socket) do
    {:ok, assign(socket, count: 0) |> load_persistent_value(:stored_count, "loaded_count")}
  end

  @impl true
  def render(%{platform_id: :swiftui} = assigns) do
    ~SWIFTUI"""
    <Text><%= @count %></Text>
    <Button phx-click="increment">Increment</Button>
    """
  end

  def handle_event("increment", _params, socket) do
    new_value = socket.assigns.count + 1
    {:noreply, assign(socket, count: new_value) |> push_persistent_value(:stored_count, new_value)}
  end

  def handle_event("loaded_count", count, socket) do
    {:noreply, assign(socket, count: count)}
  end
end

```