### PR TITLE
Rename web to html

### DIFF
--- a/lib/live_view_native/live_session.ex
+++ b/lib/live_view_native/live_session.ex
@@ -21,7 +21,7 @@ defmodule LiveViewNative.LiveSession do
         socket =
           socket
           |> assign(:native, nil)
-          |> assign(:platform_id, :web)
+          |> assign(:platform_id, :html)
 
         {:cont, socket}
     end

--- a/lib/live_view_native/platforms/web.ex
+++ b/lib/live_view_native/platforms/web.ex
@@ -5,7 +5,7 @@ defmodule LiveViewNative.Platforms.Web do
 
   defimpl LiveViewNativePlatform.Kit do
     def compile(_struct) do
-      LiveViewNativePlatform.Env.define(:web,
+      LiveViewNativePlatform.Env.define(:html,
         tag_handler: Phoenix.LiveView.HTMLEngine,
         template_extension: ".html.heex",
         template_namespace: LiveViewNativeWeb,

--- a/test/live_view_native/live_session_test.exs
+++ b/test/live_view_native/live_session_test.exs
@@ -35,7 +35,7 @@ defmodule LiveViewNative.LiveSessionTest do
 
       assert updated_socket.assigns
       assert updated_socket.assigns.native == nil
-      assert updated_socket.assigns.platform_id == :web
+      assert updated_socket.assigns.platform_id == :html
     end
   end
 end

--- a/test/live_view_native/live_view_test.exs
+++ b/test/live_view_native/live_view_test.exs
@@ -13,7 +13,7 @@ defmodule LiveViewNative.LiveViewTest do
   test "calling render_native/1 renders the correct platform for `assigns`" do
     web_context = LiveViewNativePlatform.Kit.compile(%LiveViewNative.Platforms.Web{})
     test_context = LiveViewNativePlatform.Kit.compile(%LiveViewNative.TestPlatform{})
-    web_result = TestLiveView.render(%{platform_id: :web, native: web_context})
+    web_result = TestLiveView.render(%{platform_id: :html, native: web_context})
     test_result = TestLiveView.render(%{platform_id: :lvntest, native: test_context})
 
     assert web_result.static == [
@@ -28,7 +28,7 @@ defmodule LiveViewNative.LiveViewTest do
   test "calling render/1 renders platform-specific templates inline" do
     web_context = LiveViewNativePlatform.Kit.compile(%LiveViewNative.Platforms.Web{})
     test_context = LiveViewNativePlatform.Kit.compile(%LiveViewNative.TestPlatform{})
-    web_result = TestLiveViewInline.render(%{platform_id: :web, native: web_context})
+    web_result = TestLiveViewInline.render(%{platform_id: :html, native: web_context})
     test_result = TestLiveViewInline.render(%{platform_id: :lvntest, native: test_context})
 
     assert web_result.static == ["<div>Hello from the web</div>"]

--- a/test/live_view_native_test.exs
+++ b/test/live_view_native_test.exs
@@ -6,7 +6,7 @@ defmodule LiveViewNativeTest do
 
     assert platforms
     assert is_map(platforms)
-    assert platforms["web"]
+    assert platforms["html"]
     assert platforms["lvntest"]
   end
 
@@ -23,20 +23,20 @@ defmodule LiveViewNativeTest do
     end
 
     test "when platform_id is a binary" do
-      {:ok, platform_struct} = LiveViewNative.platform("web")
+      {:ok, platform_struct} = LiveViewNative.platform("html")
 
       assert platform_struct
-      assert platform_struct.platform_id == :web
+      assert platform_struct.platform_id == :html
       assert platform_struct.platform_config == %LiveViewNative.Platforms.Web{}
     end
   end
 
   describe "platform!/1" do
     test "when platform_id is valid" do
-      platform_struct = LiveViewNative.platform!("web")
+      platform_struct = LiveViewNative.platform!("html")
 
       assert platform_struct
-      assert platform_struct.platform_id == :web
+      assert platform_struct.platform_id == :html
       assert platform_struct.platform_config == %LiveViewNative.Platforms.Web{}
     end
 


### PR DESCRIPTION
Within Phoenix `html` is used over `web`