### PR TITLE
correspond `_lvn_platform` params

### DIFF
--- a/lib/live_view_native/live_session.ex
+++ b/lib/live_view_native/live_session.ex
@@ -41,6 +41,12 @@ defmodule LiveViewNative.LiveSession do
     end
   end
 
+  defp get_platform_context(%{"_lvn_platform" => platform_id} = connect_params) do
+    connect_params
+    |> Map.put_new("_platform", platform_id)
+    |> get_platform_context()
+  end
+
   defp get_platform_context(_connect_params), do: nil
 
   defp get_platform_metadata(%{"_platform_meta" => %{} = platform_metadata}),

--- a/test/live_view_native/live_session_test.exs
+++ b/test/live_view_native/live_session_test.exs
@@ -25,6 +25,26 @@ defmodule LiveViewNative.LiveSessionTest do
       assert updated_socket.assigns.native.template_extension == ".test.heex"
     end
 
+    test "correspond _lvn_platform parameter" do
+      socket = %Socket{
+        private: %{connect_params: %{"_lvn_platform" => "lvntest"}},
+        transport_pid: self()
+      }
+
+      {:cont, updated_socket} = LiveSession.on_mount(:live_view_native, %{}, %{}, socket)
+
+      assert updated_socket.assigns
+      assert updated_socket.assigns.native
+      assert updated_socket.assigns.native.__struct__ == LiveViewNativePlatform.Env
+      assert updated_socket.assigns.native.platform_id == :lvntest
+
+      assert updated_socket.assigns.native.platform_config == %LiveViewNative.TestPlatform{
+               testing_notes: "everything is ok"
+             }
+
+      assert updated_socket.assigns.native.template_extension == ".test.heex"
+    end
+
     test "falls back to Web platform if _platform connect param is not passed" do
       socket = %Socket{
         private: %{connect_params: %{}},


### PR DESCRIPTION
via. https://github.com/liveview-native/live_view_native/issues/62

correspond to this code:
https://github.com/liveview-native/liveview-client-swiftui/blob/main/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift#L222