### PR TITLE
Allow using stylesheet modules

### DIFF
--- a/lib/live_view_native/extensions.ex
+++ b/lib/live_view_native/extensions.ex
@@ -9,7 +9,7 @@ defmodule LiveViewNative.Extensions do
   respectively.
   """
   defmacro __using__(opts \\ []) do
-    quote bind_quoted: [caller: Macro.escape(__CALLER__), stylesheet: opts[:stylesheet]] do
+    quote bind_quoted: [caller: Macro.escape(__CALLER__)] do
       for {platform_id, platform_context} <- LiveViewNative.platforms() do
         platform_module = Module.concat(__ENV__.module, platform_context.template_namespace)
 
@@ -23,7 +23,6 @@ defmodule LiveViewNative.Extensions do
             caller: caller,
             eex_engine: platform_context.eex_engine,
             platform_module: platform_module,
-            stylesheet: stylesheet,
             tag_handler: platform_context.tag_handler,
             template_basename: Path.basename(__ENV__.file) |> String.split(".") |> List.first(),
             template_directory: Path.dirname(__ENV__.file),
@@ -38,19 +37,16 @@ defmodule LiveViewNative.Extensions do
 
         use LiveViewNative.Extensions.RenderMacro,
           platform_id: platform_id,
-          render_macro: platform_context.render_macro,
-          stylesheet: stylesheet
+          render_macro: platform_context.render_macro
 
         use LiveViewNative.Extensions.InlineRender,
-          platform_id: platform_id,
-          stylesheet: stylesheet
+          platform_id: platform_id
       end
 
       use LiveViewNative.Extensions.Render
 
       use LiveViewNative.Extensions.Stylesheets,
-        module: __ENV__.module,
-        stylesheet: stylesheet
+        module: __ENV__.module
     end
   end
 end

--- a/lib/live_view_native/extensions/render_macro.ex
+++ b/lib/live_view_native/extensions/render_macro.ex
@@ -10,8 +10,7 @@ defmodule LiveViewNative.Extensions.RenderMacro do
   defmacro __using__(opts \\ []) do
     quote bind_quoted: [
             render_macro: opts[:render_macro],
-            platform_id: opts[:platform_id],
-            stylesheet: opts[:stylesheet]
+            platform_id: opts[:platform_id]
           ] do
       require EEx
 
@@ -29,7 +28,6 @@ defmodule LiveViewNative.Extensions.RenderMacro do
             file: __CALLER__.file,
             indentation: meta[:indentation] || 0,
             line: __CALLER__.line + 1,
-            stylesheet: unquote(stylesheet),
             tag_handler: LiveViewNative.TagEngine
           ]
 

--- a/lib/live_view_native/templates.ex
+++ b/lib/live_view_native/templates.ex
@@ -8,19 +8,16 @@ defmodule LiveViewNative.Templates do
     %Macro.Env{function: {func_name, _func_arity} = template_func, module: template_module} =
       eex_opts[:caller]
 
-    stylesheet = eex_opts[:stylesheet]
     doc = Meeseeks.parse(expr, :xml)
     class_names = extract_all_class_names(doc)
     class_tree_context = class_tree_context(platform_id, template_module)
     class_tree = build_class_tree(class_tree_context, class_names, template_func)
     dump_class_tree_bytecode(class_tree, template_module)
 
-    case stylesheet do
-      stylesheet when func_name == :render and not is_nil(stylesheet) ->
-        "<compiled-lvn-stylesheet body={__compiled_stylesheet__()}>\n" <> expr <> "\n</compiled-lvn-stylesheet>"
-
-      _ ->
-        expr
+    if func_name == :render do
+      "<compiled-lvn-stylesheet body={__compiled_stylesheet__()}>\n" <> expr <> "\n</compiled-lvn-stylesheet>"
+    else
+      expr
     end
   end
 
@@ -46,8 +43,7 @@ defmodule LiveViewNative.Templates do
   end
 
   defp class_tree_filename(platform_id, template_module) do
-    # TODO: Infer build path
-    "_build/#{Mix.env()}/lib/live_view_native/.lvn/#{platform_id}/#{template_module}.classtree.json"
+    "#{:code.lib_dir(:live_view_native)}/.lvn/#{platform_id}/#{template_module}.classtree.json"
   end
 
   defp dump_class_tree_bytecode(class_tree, template_module) do

--- a/test/live_view_native/live_view_test.exs
+++ b/test/live_view_native/live_view_test.exs
@@ -32,6 +32,6 @@ defmodule LiveViewNative.LiveViewTest do
     test_result = TestLiveViewInline.render(%{platform_id: :lvntest, native: test_context})
 
     assert web_result.static == ["<div>Hello from the web</div>"]
-    assert test_result.static == ["<Text>Hello from the test platform</Text>"]
+    assert test_result.static == ["<compiled-lvn-stylesheet", ">\n<Text>Hello from the test platform</Text>\n\n</compiled-lvn-stylesheet>"]
   end
 end


### PR DESCRIPTION
This PR adds the ability to `use` stylesheet modules within LiveViews and LiveComponents, like so:

```elixir
defmodule MyAppWeb.AuthLive do
  use Phoenix.LiveView
  use LiveViewNative.LiveView
  use MyAppWeb.Styles.AppStyles
  use MyAppWeb.Styles.ExtraStyles

  # ...
end
```

Any number of stylesheet modules can be inherited by a LiveView or LiveComponents and will be pushed to the client on initial render. This currently requires using the [`allow-using-stylesheets`](https://github.com/liveview-native/live_view_native/tree/allow-using-stylesheets) branch of `live_view_native_stylesheet`.

Related PR: https://github.com/liveview-native/live_view_native_stylesheet/pull/27