### PR TITLE
fix typespecs in LiveViewNative module

### DIFF
--- a/lib/live_view_native.ex
+++ b/lib/live_view_native.ex
@@ -10,7 +10,7 @@ defmodule LiveViewNative do
 
   Used to introspect platforms at compile-time or runtime.
   """
-  @spec platform(atom) :: {:ok, %LiveViewNativePlatform.Env{}} | :error
+  @spec platform(atom | String.t()) :: {:ok, %LiveViewNativePlatform.Env{}} | :error
   def platform(platform_id) when is_atom(platform_id) and not is_nil(platform_id),
     do: platform("#{platform_id}")
 
@@ -51,6 +51,6 @@ defmodule LiveViewNative do
   @doc """
   Returns a list of environment structs for all LiveView Native platforms.
   """
-  @spec platforms() :: list(%LiveViewNativePlatform.Env{})
+  @spec platforms() :: LiveViewNative.Platforms.env_platforms_map()
   def platforms, do: env_platforms()
 end

--- a/lib/live_view_native/platforms.ex
+++ b/lib/live_view_native/platforms.ex
@@ -1,6 +1,10 @@
 defmodule LiveViewNative.Platforms do
   @moduledoc false
 
+  @type env_platforms_map() :: %{
+          String.t() => %LiveViewNativePlatform.Env{}
+        }
+
   @default_platforms [LiveViewNative.Platforms.Web]
 
   @env_platforms :live_view_native
@@ -23,6 +27,7 @@ defmodule LiveViewNative.Platforms do
   which is responsible for determining which platform (web, iOS, etc.) a
   session originates from.
   """
+  @spec env_platforms() :: env_platforms_map()
   def env_platforms do
     @env_platforms
     |> Enum.map(&expand_env_platform/1)


### PR DESCRIPTION
I finally found the cause of the cryptic `pattern can never match type` warnings I get on every `use LiveViewNative.LiveView` call in my phoenix app - it's been driving me crazy! 😅 