### PR TITLE
Fixes class map truncation

### DIFF
--- a/lib/live_view_native/templates.ex
+++ b/lib/live_view_native/templates.ex
@@ -109,9 +109,10 @@ defmodule LiveViewNative.Templates do
     module_name = generate_class_tree_module_name(template_module)
     branches = get_class_tree_branches(requires)
 
-    case :ets.info(:live_view_native_class_maps) do
-      :undefined -> :ets.new(:live_view_native_class_maps, [:public, :named_table])
-      _ -> nil
+    try do
+      :ets.new(:live_view_native_class_maps, [:public, :named_table])
+    rescue
+      _ -> :already_defined
     end
 
     :ets.insert(:live_view_native_class_maps, {module_name, class_tree_map})


### PR DESCRIPTION
This resolves an issue with how the class maps were being built up. When there are are a certain number of classes extracted from a limit it exceed's Elxiir's own truncation limit when it comes to stringifying. Typically this can be worked around by setting an `:infinity` limit but in this case the code was using `Macro.to_string/1`. The quoted code being passed to `Macro.to_string` was directly printing the entire list of classses.

This was going to present sooner or later. Glad we found it now. This PR fixes it but is not a permanent fix. Instead of injecting the literal array into the code it will cache it in Ets and retrieve at runtime for the function avoiding the truncation issue of the AST being evaluated.