### PR TITLE
Fix typo in example

### DIFF
--- a/guides/introduction/overview.md
+++ b/guides/introduction/overview.md
@@ -26,9 +26,9 @@ defmodule MyAppWeb.HelloLive do
       <Button phx-click="hello">
         <Image class="fg-color-purple font-size-48 p-8" system-name="sparkles"></Image>
       </Button>
-      <VStack spacing={4}>
+      <HStack spacing={4}>
         Hello world on <Text class="bold"><%= device_name(assigns) %></Text>!
-      </VStack>
+      </HStack>
     </VStack>
     """
   end


### PR DESCRIPTION
Just a small discrepancy between the code snippet on the Introduction page of the HexDocs and what the screenshots show; it should use an `HStack` and not a `VStack`.