### PR TITLE
Fix bug where if plugin doens't have a gen task

### DIFF
--- a/lib/mix/tasks/lvn.setup.ex
+++ b/lib/mix/tasks/lvn.setup.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Lvn.Setup do
+  alias Mix.Tasks.Phx.Gen
   alias Mix.LiveViewNative.Context
 
   def run(args) do
@@ -65,7 +66,11 @@ defmodule Mix.Tasks.Lvn.Setup do
           []
         end
 
-        Mix.Task.run("lvn.#{format}.gen", args)
+        format_task_gen_module = Module.concat([Mix.Tasks.Lvn, Macro.camelize(format), Gen])
+
+        if Mix.Task.task?(format_task_gen_module) do
+          Mix.Task.run("lvn.#{format}.gen", args)
+        end
 
         Mix.Task.run("lvn.gen.layout", [format])
 


### PR DESCRIPTION
When a plugin doesn't have a gen task it should be skipped during `lvn.mix.setup`