### PR TITLE
Error mix task when module name is invalid

### DIFF
--- a/lib/mix/live_view_native/context.ex
+++ b/lib/mix/live_view_native/context.ex
@@ -69,6 +69,10 @@ defmodule Mix.LiveViewNative.Context do
     end
   end
 
+  def valid_module?(module_name) do
+    Mix.Phoenix.Context.valid?(module_name)
+  end
+
   def apps(format, default_app \\ :live_view_native) do
     plugin_otp_app_name =
       format

--- a/lib/mix/tasks/lvn.gen.live.ex
+++ b/lib/mix/tasks/lvn.gen.live.ex
@@ -19,8 +19,8 @@ defmodule Mix.Tasks.Lvn.Gen.Live do
         "mix lvn.gen.live must be invoked from within your *_web application root directory"
       )
     end
-    context = Context.build(args, __MODULE__)
 
+    context = Context.build(args, __MODULE__)
     files = files_to_be_generated(context)
 
     Context.prompt_for_conflicts(files)
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Lvn.Gen.Live do
   ]
 
   @doc false
-  def validate_args!([format, _name | _] = args) do
+  def validate_args!([format, live_view_module| _] = args) do
     cond do
       not Context.valid_format?(format) ->
         formats =
@@ -51,6 +51,11 @@ defmodule Mix.Tasks.Lvn.Gen.Live do
         Please see the documentation for how to register new LiveView Native plugins
         """)
 
+      not Context.valid_module?(live_view_module) ->
+        Mix.raise("""
+        Expected "#{live_view_module}", to be a valid module name
+        """)
+
       true ->
         args
     end
@@ -64,7 +69,7 @@ defmodule Mix.Tasks.Lvn.Gen.Live do
       |> Enum.join("\n")
 
     Mix.raise("""
-    You must pass a valid format and the name of the parent LiveView. Available formats:
+    You must pass a valid format and the name of the parent LiveView module. Available formats:
     #{formats}
 
     Example: mix lvn.gen.live swiftui Home

--- a/test/mix/tasks/lvn.gen.live_test.exs
+++ b/test/mix/tasks/lvn.gen.live_test.exs
@@ -22,6 +22,16 @@ defmodule Mix.Tasks.Lvn.Gen.LiveTest do
       end
     end
 
+    test "will raise with message if invalid schema is given", config do
+      in_tmp_live_project config.test, fn ->
+        assert_raise(Mix.Error, fn() ->
+          Gen.Live.run(["gameboy", "home"])
+        end)
+        refute_file "lib/live_view_native_web/live/gameboy/home_live.gameboy.neex"
+        refute_file "lib/live_view_native_web/live/home_live.gameboy.ex"
+      end
+    end
+
     test "will raise with message if invalid format is given", config do
       in_tmp_live_project config.test, fn ->
         assert_raise(Mix.Error, fn() ->


### PR DESCRIPTION
Do not attempt to run `mix lvn.gen.live` when the module name given is in an invalid format