### PR TITLE
Codegen improvements

### DIFF
--- a/test/mix/live_view_native/codegen_test.exs
+++ b/test/mix/live_view_native/codegen_test.exs
@@ -28,7 +28,7 @@ defmodule Mix.LiveViewNative.CodeGenTest do
 
       matcher = &(match?({:config, _, [{:__block__, _, [:logger]} | _]}, &1))
 
-      source = CodeGen.patch(source, change, inject: {:before, matcher}, path: "config/config.exs")
+      {:ok, source} = CodeGen.patch(source, change, inject: {:before, matcher}, path: "config/config.exs")
 
       assert source == """
       config :live_view_native, plugins: [
@@ -53,11 +53,7 @@ defmodule Mix.LiveViewNative.CodeGenTest do
 
       matcher = &(match?({:config, _, [{:__block__, _, [:other]} | _]}, &1))
 
-      source = CodeGen.patch(source, change, inject: {:before, matcher}, path: "config/config.exs")
-
-      assert source == """
-      config :logger, :level, :debug
-      """
+      assert {:error, _msg} = CodeGen.patch(source, change, inject: {:before, matcher}, path: "config/config.exs")
     end
 
     test "inject after" do
@@ -76,7 +72,7 @@ defmodule Mix.LiveViewNative.CodeGenTest do
 
       matcher = &(match?({:config, _, [{:__block__, _, [:logger]} | _]}, &1))
 
-      source = CodeGen.patch(source, change, inject: {:after, matcher}, path: "config/config.exs")
+      {:ok, source} = CodeGen.patch(source, change, inject: {:after, matcher}, path: "config/config.exs")
 
       assert source == """
       config :logger, :level, :debug
@@ -105,12 +101,7 @@ defmodule Mix.LiveViewNative.CodeGenTest do
 
       matcher = &(match?({:config, _, [{:__block__, _, [:other]} | _]}, &1))
 
-      source = CodeGen.patch(source, change, inject: {:after, matcher}, path: "config/config.exs")
-
-      assert source == """
-      config :logger, :level, :debug
-      config :logger, :backends, []
-      """
+      assert {:error, _msg} = CodeGen.patch(source, change, inject: {:after, matcher}, path: "config/config.exs")
     end
 
     test "inject head" do
@@ -125,7 +116,7 @@ defmodule Mix.LiveViewNative.CodeGenTest do
 
       """
 
-      source = CodeGen.patch(source, change, inject: :head)
+      {:ok, source} = CodeGen.patch(source, change, inject: :head)
 
       assert source == """
       config :live_view_native, plugins: [
@@ -148,7 +139,7 @@ defmodule Mix.LiveViewNative.CodeGenTest do
       ]
       """
 
-      source = CodeGen.patch(source, change, inject: :eof)
+      {:ok, source} = CodeGen.patch(source, change, inject: :eof)
 
       assert source == """
       config :logger, :level, :debug
@@ -178,7 +169,7 @@ defmodule Mix.LiveViewNative.CodeGenTest do
 
       merge = &merger/2
 
-      source = CodeGen.patch(source, change, merge: merge)
+      {:ok, source} = CodeGen.patch(source, change, merge: merge)
 
       assert source == """
       config :logger, :level, :debug
@@ -207,7 +198,7 @@ defmodule Mix.LiveViewNative.CodeGenTest do
 
       matcher = &(match?({:config, _, [{:__block__, _, [:logger]} | _]}, &1))
 
-      source = CodeGen.patch(source, change, merge: merge, inject: {:after, matcher}, path: "config/config.exs")
+      {:ok, source} = CodeGen.patch(source, change, merge: merge, inject: {:after, matcher}, path: "config/config.exs")
 
       assert source == """
       config :logger, :level, :debug

--- a/test/mix/tasks/lvn.setup_test.exs
+++ b/test/mix/tasks/lvn.setup_test.exs
@@ -260,7 +260,7 @@ defmodule Mix.Tasks.Lvn.SetupTest do
 
   describe "config codgen scenarios" do
     test "when :live_view_native config exists the :plugins list is updated and duplicates are removed" do
-      config = """
+      source = """
         config :live_view_native, plugins: [
           LiveViewNativeTest.Other,
           LiveViewNativeTest.Switch
@@ -269,7 +269,12 @@ defmodule Mix.Tasks.Lvn.SetupTest do
         config :logger, :level, :debug
         """
 
-      {_, {result, _}} = Config.patch_plugins({%{}, {config, "config/config.exs"}})
+      data = [
+        LiveViewNativeTest.GameBoy,
+        LiveViewNativeTest.Switch
+      ]
+
+      {:ok, result} = Config.patch_plugins(%{}, data, source, "config/config.exs")
 
       assert  result =~ """
         config :live_view_native, plugins: [
@@ -283,14 +288,16 @@ defmodule Mix.Tasks.Lvn.SetupTest do
     end
 
     test "when :mimes config exists the :types map is updated and duplicates are removed" do
-      config = """
+      source = """
         config :mime, :types, %{
           "text/other" => ["other"],
           "text/switch" => ["switch"]
         }
         """
 
-      {_, {result, _}} = Config.patch_mime_types({%{}, {config, "config/config.exs"}})
+      data = [:gameboy]
+
+      {:ok, result} = Config.patch_mime_types(%{}, data, source, "config/config.exs")
 
       assert result =~ """
         config :mime, :types, %{
@@ -302,14 +309,16 @@ defmodule Mix.Tasks.Lvn.SetupTest do
     end
 
     test "when :phonex_template config exists the :format_encoders list is updated and duplicates are removed" do
-      config = """
+      source = """
         config :phoenix_template, :format_encoders, [
           other: Other.Engine,
           switch: Phoenix.HTML.Engine
         ]
         """
 
-      {_, {result, _}} = Config.patch_format_encoders({%{}, {config, "config/config.exs"}})
+      data = [:gameboy]
+
+      {:ok, result} = Config.patch_format_encoders(%{}, data, source, "config/config.exs")
 
       assert result =~ """
         config :phoenix_template, :format_encoders, [
@@ -321,13 +330,15 @@ defmodule Mix.Tasks.Lvn.SetupTest do
     end
 
     test "when :phoenix config exists the :template_engines list is updated and duplicates are removed" do
-      config = """
+      source = """
         config :phoenix, :template_engines, [
           other: Other.Engine,
         ]
         """
 
-      {_, {result, _}} = Config.patch_template_engines({%{}, {config, "config/config.exs"}})
+      data = [{:neex, LiveViewNative.Engine}]
+
+      {:ok, result} = Config.patch_template_engines(%{}, data, source, "config/config.exs")
 
       assert result =~ """
         config :phoenix, :template_engines, [
@@ -340,7 +351,7 @@ defmodule Mix.Tasks.Lvn.SetupTest do
 
   describe "dev codgen scenarios" do
     test "when the :live_reload_patterns had additional keywords items" do
-      config = """
+      source = """
         config :live_view_native, LiveViewNativeWeb.Endpoint,
           live_reload: [
             other: :thing,
@@ -352,7 +363,11 @@ defmodule Mix.Tasks.Lvn.SetupTest do
           ]
         """
 
-      {_, {result, _}} = Config.patch_live_reload_patterns({%{context_app: :live_view_native}, {config, "config/config.exs"}})
+      data = [
+        ~s'~r"lib/live_view_native_web/(live|components)/.*neex$"'
+      ]
+
+      {:ok, result} = Config.patch_live_reload_patterns(%{context_app: :live_view_native}, data, source, "config/config.exs")
 
       assert  result =~ """
         config :live_view_native, LiveViewNativeWeb.Endpoint,
@@ -371,7 +386,7 @@ defmodule Mix.Tasks.Lvn.SetupTest do
 
   describe "router codgen scenarios" do
     test "patch_layouts when this old style of router layout option is being used, rewrite as the new keyword list with html" do
-      config = """
+      source = """
           pipeline :browser do
             plug :accepts, ["html"]
             plug :fetch_session
@@ -384,7 +399,12 @@ defmodule Mix.Tasks.Lvn.SetupTest do
           end
         """
 
-      {_, {result, _}} = Config.patch_root_layouts({%{}, {config, "live_view_native_web/router.ex"}})
+      data = [
+        {:gameboy, {LiveViewNativeWeb.Layouts.GameBoy, :root}},
+        {:switch, {LiveViewNativeWeb.Layouts.Switch, :root}},
+      ]
+
+      {:ok, result} = Config.patch_root_layouts(%{}, data, source, "live_view_native_web/router.ex")
 
       assert result =~ """
         pipeline :browser do


### PR DESCRIPTION
* `Codegen.patch/3` now returns result tuple for better error handling
* Codegens are grouped by file and type to merge all codegens for a single pass on each
* Don't error on missing files
* Don't error on unhandled codegen scenarios