### PR TITLE
Replace `Module.defines?/2` by `Kernel.function_exported?/3`

### DIFF
--- a/lib/live_view_native/content_negotiator.ex
+++ b/lib/live_view_native/content_negotiator.ex
@@ -87,7 +87,7 @@ defmodule LiveViewNative.ContentNegotiator do
   end
 
   defp normalize_os_version(%{"os_version" => os_version} = interface, plugin) when not is_nil(os_version) do
-    if Module.defines?(plugin, {:normalize_os_version, 1}) do
+    if function_exported?(plugin, :normalize_os_version, 1) do
       os_version = plugin.normalize_os_version(os_version)
       Map.put(interface, "os_version", os_version)
     else
@@ -99,7 +99,7 @@ defmodule LiveViewNative.ContentNegotiator do
     do: interface
 
   defp normalize_app_version(%{"app_version" => app_version} = interface, plugin) when not is_nil(app_version) do
-    if Module.defines?(plugin, {:normalize_app_version, 1}) do
+    if function_exported?(plugin, :normalize_app_version, 1) do
       app_version = plugin.normalize_app_version(app_version)
       Map.put(interface, "app_version", app_version)
     else


### PR DESCRIPTION
Fixes `ArgumentError`

```cmd
[error] ** (ArgumentError) could not call Module.defines?/2 because the module LiveViewNative.SwiftUI is already compiled. Use Kernel.function_exported?/3 and Kernel.macro_exported?/3 to check for public functions and macros instead
    (elixir 1.17.2) lib/module.ex:2350: Module.assert_not_compiled!/3
    (elixir 1.17.2) lib/module.ex:1158: Module.defines?/2
    (live_view_native 0.3.0) lib/live_view_native/content_negotiator.ex:90: LiveViewNative.ContentNegotiator.normalize_os_version/2
    (live_view_native 0.3.0) lib/live_view_native/content_negotiator.ex:85: LiveViewNative.ContentNegotiator.normalize_interface/2
    (live_view_native 0.3.0) lib/live_view_native/content_negotiator.ex:55: LiveViewNative.ContentNegotiator.assign_params/2
    (live_view_native 0.3.0) lib/live_view_native/content_negotiator.ex:22: LiveViewNative.ContentNegotiator.on_mount/4
    (phoenix_live_view 1.0.0-rc.6) lib/phoenix_live_view/lifecycle.ex:158: anonymous fn/4 in Phoenix.LiveView.Lifecycle.mount/3
    (phoenix_live_view 1.0.0-rc.6) lib/phoenix_live_view/lifecycle.ex:237: Phoenix.LiveView.Lifecycle.reduce_socket/3
    (phoenix_live_view 1.0.0-rc.6) lib/phoenix_live_view/utils.ex:346: anonymous fn/6 in Phoenix.LiveView.Utils.maybe_call_live_view_mount!/5
    (telemetry 1.3.0) /Users/sharevari/Code/Youimmi/MyApp/deps/telemetry/src/telemetry.erl:324: :telemetry.span/3
    (phoenix_live_view 1.0.0-rc.6) lib/phoenix_live_view/static.ex:281: Phoenix.LiveView.Static.call_mount_and_handle_params!/5
    (phoenix_live_view 1.0.0-rc.6) lib/phoenix_live_view/static.ex:116: Phoenix.LiveView.Static.render/3
    (phoenix_live_view 1.0.0-rc.6) lib/phoenix_live_view/controller.ex:39: Phoenix.LiveView.Controller.live_render/3
    (phoenix 1.7.14) lib/phoenix/router.ex:484: Phoenix.Router.__call__/5
    (my_app 0.1.0) lib/my_app_web/endpoint.ex:1: MyAppWeb.Endpoint.plug_builder_call/2
    (my_app 0.1.0) deps/plug/lib/plug/debugger.ex:141: MyAppWeb.Endpoint."call (overridable 3)"/2
    (my_app 0.1.0) lib/my_app_web/endpoint.ex:1: MyAppWeb.Endpoint.call/2
    (phoenix 1.7.14) lib/phoenix/endpoint/sync_code_reload_plug.ex:22: Phoenix.Endpoint.SyncCodeReloadPlug.do_call/4
    (bandit 1.5.7) lib/bandit/pipeline.ex:124: Bandit.Pipeline.call_plug!/2
    (bandit 1.5.7) lib/bandit/pipeline.ex:36: Bandit.Pipeline.run/4
```

**mix.exs** 

```elixir
{:live_view_native, depth: 1, github: "liveview-native/live_view_native"},
{:phoenix_live_view, depth: 1, github: "phoenixframework/phoenix_live_view"}
```