### PR TITLE
Fix typos

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,5 +34,5 @@ fail if there are any function components intended for LVN templates still using
 ### Known issues
 
 The SwiftUI client *will* fail to compile in Xcode 16.3 beta. The `SDKROOT` environment variable, which has been in Xcode for over 25 years,
-was removed in that beta relase with no explanation as to why or what should be used instead. We are working to resolve this for the upcoming
+was removed in that beta release with no explanation as to why or what should be used instead. We are working to resolve this for the upcoming
 release of Xcode.

--- a/lib/live_view_native/component.ex
+++ b/lib/live_view_native/component.ex
@@ -11,7 +11,7 @@ defmodule LiveViewNative.Component do
   LiveView Native Components differ from Phoenix Components in that they make
   use of a two-argument function instead of a single argument function. For example,
   with a Phoenix Component that has a template named `foo_bar.html.heex` it would define
-  `foo_bar/1` as the rendering function for that template when embeded. LiveView Native Components
+  `foo_bar/1` as the rendering function for that template when embedded. LiveView Native Components
   would definee `foo_bar/2` for `foo_bar.swiftui.neex` with the 1st argument still being `assigns` and
   the 2nd argument being `interface` map with information about the native client that is connecting.
 
@@ -49,7 +49,7 @@ defmodule LiveViewNative.Component do
 
       embed_templates("swiftui/home_live*", root: nil, name: :render)
 
-  Assuming there is a `swiftui/home_live.swiftui.neex` this will be embeded in the render
+  Assuming there is a `swiftui/home_live.swiftui.neex` this will be embedded in the render
   component as `render/2`.
 
   Alternatively if you do not want to use templates but the in-line rendering you can declare your own
@@ -147,7 +147,7 @@ defmodule LiveViewNative.Component do
       def __native_opts__, do: @native_opts
 
       Module.register_attribute(__MODULE__, :template_files, accumulate: true)
-      Module.register_attribute(__MODULE__, :embeded_templates_opts, accumulate: true)
+      Module.register_attribute(__MODULE__, :embedded_templates_opts, accumulate: true)
 
       import LiveViewNative.Renderer, only: [
         delegate_to_target: 1,
@@ -182,7 +182,7 @@ defmodule LiveViewNative.Component do
   @doc false
   defmacro __before_compile__(_env) do
     quote do
-      delegate_to_target :render, supress_warning: true
+      delegate_to_target :render, suppress_warning: true
     end
   end
 
@@ -206,7 +206,7 @@ defmodule LiveViewNative.Component do
 
   #### :interface-
 
-  The `:interface-` atrribute allows you to match against a given `interface` value from the client. Similar to `data-` in HTML the name that is appended
+  The `:interface-` attribute allows you to match against a given `interface` value from the client. Similar to `data-` in HTML the name that is appended
   is the key within the deeply nested value to match against. For example `:interface-target`:
 
   ```heex

--- a/lib/live_view_native/plugin_error.ex
+++ b/lib/live_view_native/plugin_error.ex
@@ -17,7 +17,7 @@ defmodule LiveViewNative.PluginError do
     message = """
 
       Attempted to fetch plugin <%= inspect format %> <%= if Enum.empty?(formats) do %> but there are no plugins configured for LiveView Native.
-      <%= doc_ref() |> String.trim_trailing() %><% else %>but no matching plugin of that format was availble.
+      <%= doc_ref() |> String.trim_trailing() %><% else %>but no matching plugin of that format was available.
       You may have misspelled the format or don't yet have it installed.
       Here are the formats LiveView Native is configured for:<%= for format <- formats do %>
           * <%= format %><% end %><% end %>

--- a/lib/live_view_native/renderer.ex
+++ b/lib/live_view_native/renderer.ex
@@ -35,7 +35,7 @@ defmodule LiveViewNative.Renderer do
       @doc false
       def __mix_recompile__? do
         files =
-          @embeded_templates_opts
+          @embedded_templates_opts
           |> Enum.reduce([], fn({root, pattern, name}, templates_acc) ->
             root
             |> LiveViewNative.Renderer.find_templates(pattern, __MODULE__, name)
@@ -59,7 +59,7 @@ defmodule LiveViewNative.Renderer do
   defmacro delegate_to_target(name, opts \\ []) do
     %{module: module} = env = __CALLER__
     render? = Module.defines?(module, {name, 1})
-    suppress_render_warning? = opts[:supress_warning] || Application.get_env(:live_view_native, :suppress_render_warning, false)
+    suppress_render_warning? = opts[:suppress_warning] || Application.get_env(:live_view_native, :suppress_render_warning, false)
 
     if render? and !suppress_render_warning? do
       IO.warn(
@@ -95,7 +95,7 @@ defmodule LiveViewNative.Renderer do
     targets for the same name: `['home_live.swiftui+watchos.neex', 'home_live.swiftui+tvos.neex', 'home_live.swiftui.neex']`
     if `name: :render` this will result:
 
-      def render(assings, %{"target" => "watchos"} = interface)
+      def render(assigns, %{"target" => "watchos"} = interface)
       def render(assigns, %{"target" => "tvos"} = interface)
       def render(assigns, interface)
 
@@ -114,7 +114,7 @@ defmodule LiveViewNative.Renderer do
     name = opts[:name]
 
     attr_ast = quote do
-      Module.put_attribute(__MODULE__, :embeded_templates_opts, {
+      Module.put_attribute(__MODULE__, :embedded_templates_opts, {
         unquote(root),
         unquote(pattern),
         unquote(name)

--- a/lib/live_view_native/template/parser.ex
+++ b/lib/live_view_native/template/parser.ex
@@ -40,7 +40,7 @@ defmodule LiveViewNative.Template.Parser do
   Or you can configure as the default:
 
   ```elixir
-  config :floki, :html_parser, LiveViewNative.Tempalte.Parser
+  config :floki, :html_parser, LiveViewNative.Template.Parser
   ```
   '''
 

--- a/lib/live_view_native_test.ex
+++ b/lib/live_view_native_test.ex
@@ -214,7 +214,7 @@ defmodule LiveViewNativeTest do
 
   ## Examples
 
-      {:ok, view, markup} = live(conn, "/path", _fromat: :gameboy)
+      {:ok, view, markup} = live(conn, "/path", _format: :gameboy)
       assert view.module == MyLive
       assert markup =~ "the count is 3"
 

--- a/test/live_view_native/template/parser_test.exs
+++ b/test/live_view_native/template/parser_test.exs
@@ -126,7 +126,7 @@ defmodule LiveViewNative.Template.ParserTest do
     ]
   end
 
-  test "will encode attriubte values" do
+  test "will encode attribute values" do
     {:ok, nodes} = """
     <FooBar baz="&lt;&gt;&amp;&quot;&#39;">&lt;&gt;&amp;&quot;&#39;</FooBar>
     """
@@ -242,7 +242,7 @@ defmodule LiveViewNative.Template.ParserTest do
        end
      end
 
-     test "catches errors with not closing tag entity propery" do
+     test "catches errors with not closing tag entity property" do
        doc = "<FooBar <Baz/>"
        {:error, _message, [start: start_pos, end: end_pos]} = parse_document(doc)
 

--- a/test/mix/live_view_native/codegen/patch_test.exs
+++ b/test/mix/live_view_native/codegen/patch_test.exs
@@ -118,7 +118,7 @@ defmodule Mix.LiveViewNative.CodeGen.PatchTest do
     end
   end
 
-  describe "dev codgen scenarios" do
+  describe "dev codegen scenarios" do
     test "when the :live_reload_patterns had additional keywords items" do
       source = """
         config :live_view_native, LiveViewNativeWeb.Endpoint,
@@ -153,7 +153,7 @@ defmodule Mix.LiveViewNative.CodeGen.PatchTest do
     end
   end
 
-  describe "router codgen scenarios" do
+  describe "router codegen scenarios" do
     test "patch_layouts when this old style of router layout option is being used, rewrite as the new keyword list with html" do
       source = """
           pipeline :browser do


### PR DESCRIPTION
Found via `codespell -S deps,_build -L gameboy,reenable,statics` and `typos --hidden --format brief`