### PR TITLE
Limit `sourceror` dep environments in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule LiveViewNative.MixProject do
       {:plug_cowboy, "~> 2.5"},
       {:ex_doc, "~> 0.24", only: :dev, runtime: false},
       {:makeup_eex, ">= 0.1.1", only: :dev, runtime: false},
-      {:sourceror, "~> 1.5"},
+      {:sourceror, "~> 1.5", only: [:dev, :test]},
       {:text_diff, "~> 0.1"},
       {:live_view_native_test_endpoint, github: "liveview-native/live_view_native_test_endpoint", branch: "main", only: :test}
     ]


### PR DESCRIPTION
Limit the `sourceror` dep availability to dev and test.

**Reason**

While trying install `live_view_native` in an existing codebase that's already using sourceror defined like:
       
```
{:sourceror, "~> 1.8", only: [:dev, :test]},
```

I'm getting this error:

```
Dependencies have diverged:
* sourceror (Hex package)
  the :only option for dependency sourceror

  > In mix.exs:
    {:sourceror, "~> 1.8", [env: :prod, hex: "sourceror", only: [:dev, :test], repo: "hexpm"]}

  does not match the :only option calculated for

  > In deps/live_view_native/mix.exs:
    {:sourceror, "~> 1.5", [env: :prod, hex: "sourceror", repo: "hexpm"]}

  Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```

If I’m not mistaken, `sourceror` isn’t required at runtime and is only used in development contexts. If that’s the case, restricting its inclusion in `live_view_native` to `only: [:dev, :test]` would prevent these dependency conflicts and avoid bringing it into production builds unnecessarily; ignore this PR otherwise.